### PR TITLE
Add Mixtral support

### DIFF
--- a/src/infer.cu
+++ b/src/infer.cu
@@ -927,6 +927,10 @@ void Block::_block_cuda(
       break;
     }
   }
+
+  if (c.n_experts > 0) {
+    assert(false && "Mixture of experts not yet supported for CUDA");
+  }
   
   // mix self.w2(F.silu(self.w1(x)) * self.w3(x))
   // Note this is a feedforward with a GLU, not a simple MLP.

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -21,6 +21,9 @@ void Config::from_yalm(YALMData& yalm, int context) {
   n_heads = std::stoi(yalm.metadata.at("n_heads").get<std::string>());
   n_kv_heads = std::stoi(yalm.metadata.at("n_kv_heads").get<std::string>());
   vocab_size = std::stoi(yalm.metadata.at("vocab_size").get<std::string>());
+  // mixture of experts
+  n_experts = std::stoi(yalm.metadata.at("n_experts").get<std::string>());
+  n_experts_active = std::stoi(yalm.metadata.at("n_experts_active").get<std::string>());
 
   // for now limit seq_len to 4096 to avoid KV cache OOM for models like Mistral since window size isn't correctly specified
   max_seq_len = std::min(std::stoi(yalm.metadata.at("max_seq_len").get<std::string>()), 4096);

--- a/src/model.h
+++ b/src/model.h
@@ -99,6 +99,10 @@ struct InferenceState {
   float* v() const { return _v; }
   float* att() const { return _att; }
   float* att(int head) const { return _att + _config->max_seq_len * head; }
+  // mixture of experts
+  float* moe_weights() const { return _moe_weights; }
+  float* active_experts_weights() const { return _active_experts_weights; }
+  int* active_experts() const { return _active_experts; }
   // LM head
   float* logits() const { return _logits; }
 
@@ -130,6 +134,10 @@ private:
   float* _k = nullptr;         // (n_kv_heads * head_dim,) - key vectors for latest timestamp
   float* _v = nullptr;         // (n_kv_heads * head_dim,) - value vectors for latest timestamp
   float* _att = nullptr;       // (n_heads, seq_len) - buffer for attention scores
+  // mixture of experts
+  float* _moe_weights = nullptr; // (n_experts,) - buffer for expert weights, decided by router
+  float* _active_experts_weights = nullptr; // (n_active_experts,) - buffer for weights of top K experts (active experts)
+  int* _active_experts = nullptr; // (n_active_experts,) - buffer for indices of top K experts (active experts)
   
   // LM head
   // NOTE: this always lives on the host (CPU), but must be registered 
@@ -150,7 +158,8 @@ struct Block {
     const Tensor* wo,
     const Tensor* w1,
     const Tensor* w2,
-    const Tensor* w3
+    const Tensor* w3,
+    const Tensor* moegate
   );
   ~Block();
 
@@ -170,6 +179,8 @@ struct Block {
   T* w2() const { return static_cast<T*>(_w2); }
   template <typename T>
   T* w3() const { return static_cast<T*>(_w3); }
+  template <typename T>
+  T* moegate() const { return static_cast<T*>(_moegate); }
   f16_t* key_cache() const { return _key_cache; }
   f16_t* value_cache() const { return _value_cache; }
 
@@ -224,6 +235,8 @@ private:
   void* _w1 = nullptr; // (n_experts?, hidden_dim, dim)
   void* _w2 = nullptr; // (n_experts?, dim, hidden_dim)
   void* _w3 = nullptr; // (n_experts?, hidden_dim, dim) - GLU weights
+  // weights for mixture of experts router if present
+  void* _moegate = nullptr; // (n_experts?, dim)
 
   // kv cache
   f16_t* _key_cache = nullptr;   // (seq_len, n_kv_heads * head_dim)

--- a/src/model.h
+++ b/src/model.h
@@ -53,6 +53,9 @@ struct Config {
   ActivationType act;       // activation function
   LayerNormType norm_type;  // norm type
   float qkv_clip;           // clip qkv values to [-clip, clip]
+  // mixture of experts
+  int n_experts;
+  int n_experts_active;
 
   // Data type of the weights according to config, used
   // to safety check tensor dtype at initialization time.


### PR DESCRIPTION
Adds mixture of experts (FFN top-K expert routing) to the CPU backend. Currently unsupported in CUDA backend. Tested only on Mixtral. 